### PR TITLE
fix: crossplane provider health in sample test

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 		Namespace: "openmcp-system",
 		Operator: setup.OpenMCPOperatorSetup{
 			Name:         "openmcp-operator",
-			Image:        "ghcr.io/openmcp-project/images/openmcp-operator:v0.13.0",
+			Image:        "ghcr.io/openmcp-project/images/openmcp-operator:v0.17.1",
 			Environment:  "debug",
 			PlatformName: "platform",
 		},
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:  "crossplane",
-				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.0.4",
+				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.1.4",
 				Opts: []wait.Option{
 					wait.WithTimeout(time.Minute),
 				},


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

Fixes the deployment of crossplane provider in the sample test feature. 
The deployment of service-provider crossplane always eventually failed after initially getting ready. 
The deployment stays healthy with the latest version.