### PR TITLE
fix: support wait options for any setup and use default timeouts

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
@@ -32,18 +30,12 @@ func TestMain(m *testing.M) {
 			{
 				Name:  "kind",
 				Image: "ghcr.io/openmcp-project/images/cluster-provider-kind:v0.0.15",
-				Opts: []wait.Option{
-					wait.WithTimeout(time.Minute),
-				},
 			},
 		},
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:  "crossplane",
 				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.1.4",
-				Opts: []wait.Option{
-					wait.WithTimeout(time.Minute),
-				},
 			},
 		},
 	}

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -47,9 +47,9 @@ spec:
 
 // ClusterProviderSetup represents the configuration parameters to set up a cluster provider
 type ClusterProviderSetup struct {
-	Name  string
-	Image string
-	Opts  []wait.Option
+	Name     string
+	Image    string
+	WaitOpts []wait.Option
 }
 
 func mcpRef(ref types.NamespacedName) *unstructured.Unstructured {
@@ -93,7 +93,7 @@ func InstallClusterProvider(ctx context.Context, c *envconf.Config, clusterProvi
 	if err != nil {
 		return err
 	}
-	return wait.For(conditions.Match(obj, c, "Ready", corev1.ConditionTrue), clusterProvider.Opts...)
+	return wait.For(conditions.Match(obj, c, "Ready", corev1.ConditionTrue), clusterProvider.WaitOpts...)
 }
 
 // DeleteClusterProvider deletes the cluster provider object and waits until the object has been deleted

--- a/pkg/providers/serviceprovider.go
+++ b/pkg/providers/serviceprovider.go
@@ -28,9 +28,9 @@ spec:
 
 // ServiceProviderSetup represents the configuration parameters to set up a service provider
 type ServiceProviderSetup struct {
-	Name  string
-	Image string
-	Opts  []wait.Option
+	Name     string
+	Image    string
+	WaitOpts []wait.Option
 }
 
 func serviceProviderRef(name string) *unstructured.Unstructured {
@@ -51,7 +51,7 @@ func InstallServiceProvider(ctx context.Context, c *envconf.Config, sp ServicePr
 	if err != nil {
 		return err
 	}
-	return wait.For(conditions.Match(obj, c, "Ready", corev1.ConditionTrue), sp.Opts...)
+	return wait.For(conditions.Match(obj, c, "Ready", corev1.ConditionTrue), sp.WaitOpts...)
 }
 
 // ImportServiceProviderAPIs iterates over each resource from the passed in directory


### PR DESCRIPTION
This PR adds wait options for any setup and use default timeouts in sample test.

**What this PR does / why we need it**:
Fixes ci pipeline failures caused by timeouts being too short in some executions

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
