### PR TITLE
feat: workload cluster support

### DIFF
--- a/pkg/setup/config/operator.yaml.tmpl
+++ b/pkg/setup/config/operator.yaml.tmpl
@@ -44,6 +44,11 @@ data:
             spec:
               profile: kind
               tenancy: Shared
+        workload:
+          template:
+            spec:
+              profile: kind
+              tenancy: Shared
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR allows service providers to successfully request a workload cluster by creating a `ClusterRequest` with purpose `workload`.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
allow service providers to request workload clusters
```
