### PR TITLE
feat: support local dev images for any bootstrap component

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -17,9 +17,6 @@ var testenv env.Environment
 
 func TestMain(m *testing.M) {
 	initLogging()
-	serviceProviderImage := "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.1.4"
-	clusterProviderImage := "ghcr.io/openmcp-project/images/cluster-provider-kind:v0.1.0"
-	setup.MustPullImages(clusterProviderImage, serviceProviderImage)
 	openmcp := setup.OpenMCPSetup{
 		Namespace: "openmcp-system",
 		Operator: setup.OpenMCPOperatorSetup{
@@ -31,13 +28,13 @@ func TestMain(m *testing.M) {
 		ClusterProviders: []providers.ClusterProviderSetup{
 			{
 				Name:  "kind",
-				Image: clusterProviderImage,
+				Image: "ghcr.io/openmcp-project/images/cluster-provider-kind:v0.1.0",
 			},
 		},
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:  "crossplane",
-				Image: serviceProviderImage,
+				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.1.4",
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.2
 
 require (
 	github.com/stretchr/testify v1.11.1
-	github.com/vladimirvivien/gexe v0.5.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -18,6 +17,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/vladimirvivien/gexe v0.5.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -50,6 +50,8 @@ type ClusterProviderSetup struct {
 	Name     string
 	Image    string
 	WaitOpts []wait.Option
+	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	LoadImageToCluster bool
 }
 
 func mcpRef(ref types.NamespacedName) *unstructured.Unstructured {

--- a/pkg/providers/serviceprovider.go
+++ b/pkg/providers/serviceprovider.go
@@ -31,6 +31,8 @@ type ServiceProviderSetup struct {
 	Name     string
 	Image    string
 	WaitOpts []wait.Option
+	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	LoadImageToCluster bool
 }
 
 func serviceProviderRef(name string) *unstructured.Unstructured {

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -3,8 +3,6 @@ package setup
 import (
 	"context"
 	"embed"
-	"encoding/json"
-	"fmt"
 	"os"
 
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
@@ -16,8 +14,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/pkg/types"
 	"sigs.k8s.io/e2e-framework/support/kind"
-
-	"github.com/vladimirvivien/gexe"
 
 	"github.com/openmcp-project/openmcp-testing/internal"
 	"github.com/openmcp-project/openmcp-testing/pkg/providers"
@@ -42,6 +38,8 @@ type OpenMCPOperatorSetup struct {
 	Environment  string
 	PlatformName string
 	WaitOpts     []wait.Option
+	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	LoadImageToCluster bool
 }
 
 // Bootstrap sets up the minimum set of components of an openMCP installation and returns the platform cluster name
@@ -138,11 +136,18 @@ func (s *OpenMCPSetup) installServiceProviders() env.Func {
 
 func (s *OpenMCPSetup) loadImagesToCluster(platformCluster string) env.Func {
 	funcs := []env.Func{}
+	if s.Operator.LoadImageToCluster {
+		funcs = append(funcs, envfuncs.LoadDockerImageToCluster(platformCluster, s.Operator.Image))
+	}
 	for _, cp := range s.ClusterProviders {
-		funcs = append(funcs, envfuncs.LoadDockerImageToCluster(platformCluster, cp.Image))
+		if cp.LoadImageToCluster {
+			funcs = append(funcs, envfuncs.LoadDockerImageToCluster(platformCluster, cp.Image))
+		}
 	}
 	for _, sp := range s.ServiceProviders {
-		funcs = append(funcs, envfuncs.LoadDockerImageToCluster(platformCluster, sp.Image))
+		if sp.LoadImageToCluster {
+			funcs = append(funcs, envfuncs.LoadDockerImageToCluster(platformCluster, sp.Image))
+		}
 	}
 	return Compose(funcs...)
 }
@@ -158,40 +163,4 @@ func Compose(envfuncs ...env.Func) env.Func {
 		}
 		return ctx, nil
 	}
-}
-
-// MustPullImages pulls the provided images, including each manifest digest
-func MustPullImages(images ...string) {
-	for _, img := range images {
-		klog.Info("Pulling ", img)
-		runner := gexe.New()
-		if p := runner.RunProc(fmt.Sprintf("docker pull %s", img)); p.Err() != nil {
-			panic(fmt.Errorf("docker pull %v failed: %w: %s", img, p.Err(), p.Result()))
-		}
-		p := runner.RunProc(fmt.Sprintf("docker buildx imagetools inspect --raw %s", img))
-		if p.Err() != nil {
-			panic(fmt.Errorf("docker buildx imagetools inspect --raw %v failed: %w: %s", img, p.Err(), p.Result()))
-		}
-		decoder := json.NewDecoder(p.Out())
-		manifests := &imageManifests{}
-		if err := decoder.Decode(manifests); err != nil {
-			panic(fmt.Errorf("manifest decoding failed: %v", err))
-		}
-		for _, man := range manifests.Manifests {
-			klog.Infof("Pulling %s@%s", img, man.Digest)
-			p := runner.RunProc(fmt.Sprintf("docker pull %s@%s", img, man.Digest))
-			klog.V(4).Info(p.Out())
-			if p.Err() != nil {
-				panic(fmt.Errorf("docker pull %v failed: %w: %s", img, p.Err(), p.Result()))
-			}
-		}
-	}
-}
-
-type imageManifests struct {
-	Manifests []imageManifestDigest `json:"manifests"`
-}
-
-type imageManifestDigest struct {
-	Digest string `json:"digest"`
 }


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR introduces support to use local dev images for any bootstrap component. This is required to enable any kind of local development, not just service providers.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
tested with cp-kind in context of https://github.com/openmcp-project/cluster-provider-kind/pull/112

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
local dev image support for any bootstrap component
```
