### PR TITLE
feat: reusable e2e test setups

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -37,6 +37,15 @@ func TestMain(m *testing.M) {
 			{
 				Name:  "crossplane",
 				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.4.1",
+				// To iterate on a locally-built same-tag image of this SP,
+				// set LoadImageToCluster: true. In reuse mode
+				// (E2E_REUSE_CLUSTER=true) that flag also makes Bootstrap
+				// delete and re-create this ServiceProvider so the operator
+				// runs its full reconciliation again against the freshly-
+				// loaded image. Disabled here because this SP's image isn't
+				// built locally.
+				//
+				// LoadImageToCluster: true,
 			},
 		},
 		PlatformServices: []platformservices.PlatformServiceSetup{

--- a/e2e/serviceprovider_test.go
+++ b/e2e/serviceprovider_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openmcp-project/openmcp-testing/pkg/clusterutils"
 	"github.com/openmcp-project/openmcp-testing/pkg/providers"
+	"github.com/openmcp-project/openmcp-testing/pkg/setup"
 )
 
 func TestServiceProvider(t *testing.T) {
@@ -53,7 +54,30 @@ func TestServiceProvider(t *testing.T) {
 			}
 			return ctx
 		}).
-		Teardown(providers.DeleteMCP("test-mcp", wait.WithTimeout(time.Minute)))
+		// Delete the dummy ConfigMaps so the next reuse run starts without them.
+		// On a re-run, the import Setups go through CreateOrUpdate, see NotFound,
+		// and re-create them — the earlier "verify ... objects" assesses then
+		// pass again. This is the built-in regression check for the
+		// reuse-cluster idempotency contract.
+		Assess("dummy configmaps can be deleted (re-created on next reuse run)", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			onboardingCfg, err := clusterutils.OnboardingConfig()
+			if err != nil {
+				t.Error(err)
+				return ctx
+			}
+			deleteDummyConfigMap(ctx, t, onboardingCfg)
+			mcpCfg, err := clusterutils.MCPConfig(ctx, c, "test-mcp")
+			if err != nil {
+				t.Error(err)
+				return ctx
+			}
+			deleteDummyConfigMap(ctx, t, mcpCfg)
+			return ctx
+		})
+	if !setup.IsReuseMode() {
+		basicProviderTest = basicProviderTest.
+			Teardown(providers.DeleteMCP("test-mcp", wait.WithTimeout(time.Minute)))
+	}
 	testenv.Test(t, basicProviderTest.Feature())
 }
 
@@ -66,5 +90,14 @@ func assertDummyConfigMap(ctx context.Context, t *testing.T, cfg *envconf.Config
 	v, ok := cm.Data["foo"]
 	if !ok || v != "bar" {
 		t.Errorf("expected foo:bar; got: %t %v", ok, v)
+	}
+}
+
+func deleteDummyConfigMap(ctx context.Context, t *testing.T, cfg *envconf.Config) {
+	cm := &corev1.ConfigMap{}
+	cm.SetName("dummy")
+	cm.SetNamespace(corev1.NamespaceDefault)
+	if err := cfg.Client().Resources().Delete(ctx, cm); err != nil {
+		t.Errorf("delete dummy configmap: %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	k8s.io/component-base v0.36.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
-	sigs.k8s.io/controller-runtime v0.23.3 // indirect
+	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kind v0.31.0
 	sigs.k8s.io/yaml v1.6.0

--- a/pkg/platformservices/platformservice.go
+++ b/pkg/platformservices/platformservice.go
@@ -29,7 +29,12 @@ type PlatformServiceSetup struct {
 	Name     string
 	Image    string
 	WaitOpts []wait.Option
-	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	// LoadImageToCluster, when true, loads the local image into the kind
+	// nodes on every Bootstrap. In reuse mode (E2E_REUSE_CLUSTER=true) it
+	// additionally deletes and re-creates this PlatformService CR so the
+	// operator runs its full reconciliation again (init job + run deployment
+	// + Ready), picking up the freshly-loaded image. This flag is the
+	// entry point for the same-tag local-rebuild dev loop.
 	LoadImageToCluster bool
 	// PlatformServiceConfigsDir is an optional directory containing the platform service specific
 	// resources that shall be applied during deployment of the platform service

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -51,7 +51,12 @@ type ClusterProviderSetup struct {
 	Name     string
 	Image    string
 	WaitOpts []wait.Option
-	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	// LoadImageToCluster, when true, loads the local image into the kind
+	// nodes on every Bootstrap. In reuse mode (E2E_REUSE_CLUSTER=true) it
+	// additionally deletes and re-creates this ClusterProvider CR so the
+	// operator runs its full reconciliation again (init job + run deployment
+	// + Ready), picking up the freshly-loaded image. This flag is the
+	// entry point for the same-tag local-rebuild dev loop.
 	LoadImageToCluster bool
 }
 

--- a/pkg/providers/serviceprovider.go
+++ b/pkg/providers/serviceprovider.go
@@ -31,7 +31,12 @@ type ServiceProviderSetup struct {
 	Name     string
 	Image    string
 	WaitOpts []wait.Option
-	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	// LoadImageToCluster, when true, loads the local image into the kind
+	// nodes on every Bootstrap. In reuse mode (E2E_REUSE_CLUSTER=true) it
+	// additionally deletes and re-creates this ServiceProvider CR so the
+	// operator runs its full reconciliation again (init job + run deployment
+	// + Ready), picking up the freshly-loaded image. This flag is the
+	// entry point for the same-tag local-rebuild dev loop.
 	LoadImageToCluster bool
 }
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -2,11 +2,14 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -51,11 +54,75 @@ func CreateObjectFromTemplate(ctx context.Context, cfg *envconf.Config, template
 	if err != nil {
 		return nil, err
 	}
-	err = cfg.Client().Resources().Create(ctx, obj)
-	if err != nil {
+	if err := CreateOrUpdate(ctx, cfg, obj); err != nil {
 		return nil, err
 	}
 	return obj, nil
+}
+
+// CreateOrUpdate creates obj if it does not exist on the server; otherwise it
+// copies obj's spec, labels, and annotations onto the live object and updates
+// it. status is never touched. Idempotent re-applies that produce no semantic
+// change skip the Update entirely (controllerutil.CreateOrUpdate's deep-equal
+// optimization).
+//
+// The intent is to make install paths idempotent so that the test harness can
+// be re-run against an existing cluster (see E2E_REUSE_CLUSTER) and propagate
+// spec changes (e.g. a new image) without erroring on AlreadyExists.
+func CreateOrUpdate(ctx context.Context, cfg *envconf.Config, obj client.Object) error {
+	crClient, err := client.New(cfg.Client().RESTConfig(), client.Options{
+		Scheme: cfg.Client().Resources().GetScheme(),
+	})
+	if err != nil {
+		return fmt.Errorf("CreateOrUpdate: build client: %w", err)
+	}
+	desired := obj.DeepCopyObject().(client.Object)
+	_, err = controllerutil.CreateOrUpdate(ctx, crClient, obj, func() error {
+		return mergeDesiredIntoLive(desired, obj)
+	})
+	return err
+}
+
+func mergeDesiredIntoLive(desired, live client.Object) error {
+	du, ok := desired.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("CreateOrUpdate: desired must be *unstructured.Unstructured, got %T", desired)
+	}
+	lu, ok := live.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("CreateOrUpdate: live must be *unstructured.Unstructured, got %T", live)
+	}
+	// controllerutil.CreateOrUpdate asserts that name and namespace are
+	// unchanged between pre-Get and post-mutate. For cluster-scoped resources
+	// (e.g. ClusterRoleBinding) the API server returns metadata.namespace=""
+	// even when our caller stamped one via decoder.MutateNamespace, which
+	// would otherwise trip the assertion. Restore both fields from desired
+	// so the key invariant holds; cluster-scoped Updates ignore namespace.
+	lu.SetName(du.GetName())
+	lu.SetNamespace(du.GetNamespace())
+	spec, found, err := unstructured.NestedFieldCopy(du.Object, "spec")
+	if err != nil {
+		return err
+	}
+	if found {
+		lu.Object["spec"] = spec
+	}
+	lu.SetLabels(mergeStringMap(lu.GetLabels(), du.GetLabels()))
+	lu.SetAnnotations(mergeStringMap(lu.GetAnnotations(), du.GetAnnotations()))
+	return nil
+}
+
+func mergeStringMap(into, from map[string]string) map[string]string {
+	if len(from) == 0 {
+		return into
+	}
+	if into == nil {
+		into = make(map[string]string, len(from))
+	}
+	for k, v := range from {
+		into[k] = v
+	}
+	return into
 }
 
 func createObjectsFromManifest(ctx context.Context, cfg *envconf.Config, manifest string) (*unstructured.UnstructuredList, error) {
@@ -84,6 +151,6 @@ func createAndPopulateList(ctx context.Context, obj k8s.Object, list *unstructur
 		return err
 	}
 	list.Items = append(list.Items, *u)
-	klog.Infof("creating object (%s) %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
-	return decoder.CreateIgnoreAlreadyExists(cfg.Client().Resources())(ctx, obj)
+	klog.Infof("applying object (%s) %s/%s", obj.GetObjectKind().GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+	return CreateOrUpdate(ctx, cfg, u)
 }

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -56,7 +56,14 @@ type OpenMCPOperatorSetup struct {
 	Environment  string
 	PlatformName string
 	WaitOpts     []wait.Option
-	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
+	// LoadImageToCluster, when true, loads the local image into the kind
+	// nodes on every Bootstrap. In reuse mode (E2E_REUSE_CLUSTER=true) it
+	// additionally deletes the operator's Deployment and re-applies the
+	// operator manifest after the install chain so a freshly-loaded same-tag
+	// image actually replaces the running pod. This flag is the
+	// entry point for the same-tag local-rebuild dev loop. No-op outside
+	// reuse mode beyond the kind load itself (fresh bootstraps deploy with
+	// the loaded image immediately).
 	LoadImageToCluster bool
 }
 
@@ -88,7 +95,8 @@ func (s *OpenMCPSetup) Bootstrap(testenv env.Environment) string {
 		Setup(s.installExtensions()).
 		Setup(s.verifyEnvironment()).
 		Setup(s.installPlatformServices()).
-		Setup(s.installServiceProviders())
+		Setup(s.installServiceProviders()).
+		Setup(s.rolloutOnReuseDeployments(operatorTemplate))
 	if !reuseMode {
 		testenv.
 			Finish(s.cleanup(kindConfig, operatorTemplate)).
@@ -298,6 +306,50 @@ func Compose(envfuncs ...env.Func) env.Func {
 			var err error
 			if ctx, err = envfunc(ctx, cfg); err != nil {
 				return ctx, err
+			}
+		}
+		return ctx, nil
+	}
+}
+
+// rolloutOnReuseDeployments returns an env.Func that, when E2E_REUSE_CLUSTER
+// is set, deletes-and-recreates every component whose owning Setup struct has
+// LoadImageToCluster: true. SP/CP/PS each go through the operator's full
+// reconciliation (init job + run deployment + Ready). The Operator itself
+// gets its Deployment deleted and the operator manifest re-applied. No-op
+// outside reuse mode.
+func (s *OpenMCPSetup) rolloutOnReuseDeployments(operatorTemplate string) env.Func {
+	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
+		if !IsReuseMode() {
+			return ctx, nil
+		}
+		if s.Operator.LoadImageToCluster {
+			if err := recreateOperator(ctx, c, s.Operator, operatorTemplate); err != nil {
+				return ctx, fmt.Errorf("rollout operator %q: %w", s.Operator.Name, err)
+			}
+		}
+		for _, sp := range s.ServiceProviders {
+			if !sp.LoadImageToCluster {
+				continue
+			}
+			if err := recreateServiceProvider(ctx, c, sp.Name, sp.Image, sp.WaitOpts...); err != nil {
+				return ctx, fmt.Errorf("rollout service provider %q: %w", sp.Name, err)
+			}
+		}
+		for _, cp := range s.ClusterProviders {
+			if !cp.LoadImageToCluster {
+				continue
+			}
+			if err := recreateClusterProvider(ctx, c, cp.Name, cp.Image, cp.WaitOpts...); err != nil {
+				return ctx, fmt.Errorf("rollout cluster provider %q: %w", cp.Name, err)
+			}
+		}
+		for _, ps := range s.PlatformServices {
+			if !ps.LoadImageToCluster {
+				continue
+			}
+			if err := recreatePlatformService(ctx, c, ps.Name, ps.Image, ps.WaitOpts...); err != nil {
+				return ctx, fmt.Errorf("rollout platform service %q: %w", ps.Name, err)
 			}
 		}
 		return ctx, nil

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -158,20 +158,20 @@ func (s *OpenMCPSetup) managePlatformCluster(platformClusterName string) env.Fun
 		klog.Info("create platform cluster resource...")
 
 		platformCluster := &unstructured.Unstructured{
-			Object: map[string]interface{}{
+			Object: map[string]any{
 				"apiVersion": "clusters.openmcp.cloud/v1alpha1",
 				"kind":       "Cluster",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "platform",
 					"namespace": s.Namespace,
-					"annotations": map[string]string{
+					"annotations": map[string]any{
 						"kind.clusters.openmcp.cloud/name": platformClusterName,
 					},
 				},
-				"spec": map[string]interface{}{
-					"kubernetes": map[string]interface{}{},
+				"spec": map[string]any{
+					"kubernetes": map[string]any{},
 					"profile":    "kind",
-					"purposes": []interface{}{
+					"purposes": []any{
 						clustersv1alpha1.PURPOSE_PLATFORM,
 					},
 					"tenancy": string(clustersv1alpha1.TENANCY_SHARED),
@@ -180,7 +180,7 @@ func (s *OpenMCPSetup) managePlatformCluster(platformClusterName string) env.Fun
 		}
 
 		// Create the platform cluster object in Kubernetes
-		if createErr := c.Client().Resources().Create(ctx, platformCluster); createErr != nil {
+		if createErr := resources.CreateOrUpdate(ctx, c, platformCluster); createErr != nil {
 			return ctx, createErr
 		}
 

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -29,14 +30,23 @@ import (
 //go:embed config/*
 var configFS embed.FS
 
+// DefaultPlatformClusterName is the kind cluster name used when
+// OpenMCPSetup.PlatformClusterName is empty. Override the field in your
+// TestMain if you need a per-project name (e.g. to avoid collisions across
+// consumer repos sharing one machine).
+const DefaultPlatformClusterName = "e2e-platform"
+
 type OpenMCPSetup struct {
-	Namespace        string
-	Operator         OpenMCPOperatorSetup
-	ClusterProviders []providers.ClusterProviderSetup
-	ServiceProviders []providers.ServiceProviderSetup
-	PlatformServices []platformservices.PlatformServiceSetup
-	Extensions       []extensions.Extension
-	WaitOpts         []wait.Option
+	Namespace string
+	// PlatformClusterName overrides the kind cluster name used for the
+	// platform cluster. Empty means DefaultPlatformClusterName.
+	PlatformClusterName string
+	Operator            OpenMCPOperatorSetup
+	ClusterProviders    []providers.ClusterProviderSetup
+	ServiceProviders    []providers.ServiceProviderSetup
+	PlatformServices    []platformservices.PlatformServiceSetup
+	Extensions          []extensions.Extension
+	WaitOpts            []wait.Option
 }
 
 type OpenMCPOperatorSetup struct {
@@ -50,14 +60,27 @@ type OpenMCPOperatorSetup struct {
 	LoadImageToCluster bool
 }
 
-// Bootstrap sets up the minimum set of components of an openMCP installation and returns the platform cluster name
+// Bootstrap sets up the minimum set of components of an openMCP installation and returns the platform cluster name.
+//
+// The platform kind cluster name comes from OpenMCPSetup.PlatformClusterName
+// (default DefaultPlatformClusterName). When E2E_REUSE_CLUSTER is truthy, the
+// kind cluster is reused across runs (kind's own Create handles the existence
+// case) and the framework Finish/cleanup hooks are not registered so the
+// cluster survives.
 func (s *OpenMCPSetup) Bootstrap(testenv env.Environment) string {
 	kindConfig := internal.MustTmpFileFromEmbedFS(configFS, "config/kind-config.yaml")
 	operatorTemplate := internal.MustTmpFileFromEmbedFS(configFS, "config/operator.yaml.tmpl")
-	platformClusterName := envconf.RandomName("platform", 16)
+	platformClusterName := s.PlatformClusterName
+	if platformClusterName == "" {
+		platformClusterName = DefaultPlatformClusterName
+	}
+	reuseMode := IsReuseMode()
+	if reuseMode {
+		klog.Infof("reuse mode on: kind cluster %q (%s=true)", platformClusterName, EnvReuseCluster)
+	}
 	s.Operator.Namespace = s.Namespace
 	testenv.Setup(createPlatformCluster(platformClusterName, kindConfig)).
-		Setup(envfuncs.CreateNamespace(s.Namespace)).
+		Setup(createNamespaceIdempotent(s.Namespace)).
 		Setup(s.loadImagesToCluster(platformClusterName)).
 		Setup(s.installOpenMCPOperator(operatorTemplate)).
 		Setup(s.installClusterProviders()).
@@ -65,15 +88,33 @@ func (s *OpenMCPSetup) Bootstrap(testenv env.Environment) string {
 		Setup(s.installExtensions()).
 		Setup(s.verifyEnvironment()).
 		Setup(s.installPlatformServices()).
-		Setup(s.installServiceProviders()).
-		Finish(s.cleanup(kindConfig, operatorTemplate)).
-		Finish(envfuncs.DestroyCluster(platformClusterName))
+		Setup(s.installServiceProviders())
+	if !reuseMode {
+		testenv.
+			Finish(s.cleanup(kindConfig, operatorTemplate)).
+			Finish(envfuncs.DestroyCluster(platformClusterName))
+	}
 	return platformClusterName
 }
 
 func createPlatformCluster(name string, kindConfig string) types.EnvFunc {
 	klog.Info("create platform cluster...")
 	return envfuncs.CreateClusterWithConfig(kind.NewProvider(), name, kindConfig)
+}
+
+// createNamespaceIdempotent wraps envfuncs.CreateNamespace so a re-run against
+// an existing cluster does not error on AlreadyExists. It mirrors what
+// envfuncs.CreateNamespace puts on the env config (default namespace) so
+// downstream Setup steps see the same state regardless.
+func createNamespaceIdempotent(name string) types.EnvFunc {
+	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
+		ctx, err := envfuncs.CreateNamespace(name)(ctx, c)
+		if err != nil && apierrors.IsAlreadyExists(err) {
+			c.WithNamespace(name)
+			return ctx, nil
+		}
+		return ctx, err
+	}
 }
 
 func (s *OpenMCPSetup) cleanup(tmpFiles ...string) types.EnvFunc {

--- a/pkg/setup/reuse.go
+++ b/pkg/setup/reuse.go
@@ -1,0 +1,40 @@
+package setup
+
+import (
+	"os"
+	"strconv"
+)
+
+// EnvReuseCluster, when set to a truthy value, opts the test harness into
+// reuse mode: an existing kind cluster (created by a previous run) is
+// reused, install paths are still applied (idempotently), and the
+// framework-level Finish/cleanup chain is skipped so the cluster survives
+// the run.
+//
+// The cluster name is taken from OpenMCPSetup.PlatformClusterName (defaults
+// to "e2e-platform"); set it in your TestMain to a project-specific value if
+// you run multiple consumers on the same machine.
+const EnvReuseCluster = "E2E_REUSE_CLUSTER"
+
+// IsReuseMode reports whether E2E_REUSE_CLUSTER is set to a truthy value.
+// Use this in test code to gate feature.Teardown calls (e.g. providers.DeleteMCP)
+// that you want to skip when reusing the cluster across runs:
+//
+//	f := feature.New("...").Setup(providers.CreateMCP(name))
+//	if !setup.IsReuseMode() {
+//	    f = f.Teardown(providers.DeleteMCP(name))
+//	}
+func IsReuseMode() bool {
+	return parseBoolEnv(os.Getenv(EnvReuseCluster))
+}
+
+func parseBoolEnv(v string) bool {
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/pkg/setup/rollout.go
+++ b/pkg/setup/rollout.go
@@ -1,0 +1,128 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	klientconditions "sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+
+	openmcpconditions "github.com/openmcp-project/openmcp-testing/pkg/conditions"
+	"github.com/openmcp-project/openmcp-testing/pkg/resources"
+)
+
+// recreateServiceProvider, recreateClusterProvider, recreatePlatformService
+// implement the LoadImageToCluster reuse-mode rollout for SP/CP/PS: delete
+// the CR by name, wait for deletion, re-create it with the configured image,
+// then wait for Ready=True. The operator owns the rest of the reconciliation
+// (init job + run deployment + readiness condition), so this exercises the
+// full operator path on each reuse run.
+
+func recreateServiceProvider(ctx context.Context, c *envconf.Config, name, image string, waitOpts ...wait.Option) error {
+	return recreateOpenMCPCR(ctx, c, schema.GroupVersionKind{
+		Group:   "openmcp.cloud",
+		Version: "v1alpha1",
+		Kind:    "ServiceProvider",
+	}, name, image, waitOpts...)
+}
+
+func recreateClusterProvider(ctx context.Context, c *envconf.Config, name, image string, waitOpts ...wait.Option) error {
+	return recreateOpenMCPCR(ctx, c, schema.GroupVersionKind{
+		Group:   "openmcp.cloud",
+		Version: "v1alpha1",
+		Kind:    "ClusterProvider",
+	}, name, image, waitOpts...)
+}
+
+func recreatePlatformService(ctx context.Context, c *envconf.Config, name, image string, waitOpts ...wait.Option) error {
+	return recreateOpenMCPCR(ctx, c, schema.GroupVersionKind{
+		Group:   "openmcp.cloud",
+		Version: "v1alpha1",
+		Kind:    "PlatformService",
+	}, name, image, waitOpts...)
+}
+
+// recreateOpenMCPCR is the shared implementation: delete the CR identified by
+// gvk + name, wait for the API server to confirm deletion (which lets the
+// operator finalize), then re-apply with the same spec.image and wait for the
+// Ready condition. ResourceDeleted polls; the operator's controllers tear
+// down the dependent Deployment/Job during this window.
+func recreateOpenMCPCR(ctx context.Context, c *envconf.Config, gvk schema.GroupVersionKind, name, image string, waitOpts ...wait.Option) error {
+	klog.Infof("LoadImageToCluster reuse: deleting %s/%s", gvk.Kind, name)
+	ref := &unstructured.Unstructured{}
+	ref.SetGroupVersionKind(gvk)
+	ref.SetName(name)
+	if err := c.Client().Resources().Delete(ctx, ref); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete %s/%s: %w", gvk.Kind, name, err)
+	}
+	allOpts := append([]wait.Option{wait.WithImmediate()}, waitOpts...)
+	if err := wait.For(klientconditions.New(c.Client().Resources()).ResourceDeleted(ref), allOpts...); err != nil {
+		return fmt.Errorf("wait %s/%s deletion: %w", gvk.Kind, name, err)
+	}
+
+	klog.Infof("LoadImageToCluster reuse: re-creating %s/%s", gvk.Kind, name)
+	desired := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": gvk.GroupVersion().String(),
+			"kind":       gvk.Kind,
+			"metadata":   map[string]any{"name": name},
+			"spec":       map[string]any{"image": image},
+		},
+	}
+	if err := resources.CreateOrUpdate(ctx, c, desired); err != nil {
+		return fmt.Errorf("recreate %s/%s: %w", gvk.Kind, name, err)
+	}
+
+	klog.Infof("LoadImageToCluster reuse: waiting for %s/%s Ready=True", gvk.Kind, name)
+	if err := wait.For(openmcpconditions.Match(desired, c, "Ready", corev1.ConditionTrue), allOpts...); err != nil {
+		return fmt.Errorf("wait %s/%s Ready: %w", gvk.Kind, name, err)
+	}
+	klog.Infof("LoadImageToCluster reuse: %s/%s rollout complete", gvk.Kind, name)
+	return nil
+}
+
+// recreateOperator handles the LoadImageToCluster reuse-mode rollout for
+// OpenMCPOperatorSetup. The operator isn't an SP-style CR — it's a raw
+// Deployment + ServiceAccount + ClusterRoleBinding + ConfigMap stack applied
+// from operator.yaml.tmpl. To trigger a rollout we delete the operator's
+// Deployment, wait, then re-apply the manifest via
+// CreateObjectsFromTemplateFile and wait for DeploymentAvailable.
+//
+// TODO: this path does NOT re-run the operator's own init Job. The init Job
+// is part of operator.yaml.tmpl; if it already exists from a prior run, the
+// re-apply through CreateOrUpdate updates its spec but a completed Job won't
+// re-run on a spec update. SP/CP/PS recreate sidesteps this because the
+// operator owns the dependent Job's lifecycle and re-creates it on its own
+// reconcile. To exercise the operator's init code on reuse, we'd need to
+// explicitly delete the existing operator init Job here. Filing as a known
+// gap; not a regression vs. pre-LoadImageToCluster-reuse behavior.
+func recreateOperator(ctx context.Context, c *envconf.Config, op OpenMCPOperatorSetup, operatorTemplate string) error {
+	klog.Infof("LoadImageToCluster reuse: deleting operator Deployment %s/%s", op.Namespace, op.Name)
+	dep := &unstructured.Unstructured{}
+	dep.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	dep.SetName(op.Name)
+	dep.SetNamespace(op.Namespace)
+	if err := c.Client().Resources().Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete operator Deployment: %w", err)
+	}
+	allOpts := append([]wait.Option{wait.WithImmediate()}, op.WaitOpts...)
+	if err := wait.For(klientconditions.New(c.Client().Resources()).ResourceDeleted(dep), allOpts...); err != nil {
+		return fmt.Errorf("wait operator Deployment deletion: %w", err)
+	}
+
+	klog.Infof("LoadImageToCluster reuse: re-applying operator manifest")
+	if _, err := resources.CreateObjectsFromTemplateFile(ctx, c, operatorTemplate, op); err != nil {
+		return fmt.Errorf("re-apply operator manifest: %w", err)
+	}
+	if err := wait.For(klientconditions.New(c.Client().Resources()).DeploymentAvailable(op.Name, op.Namespace), allOpts...); err != nil {
+		return fmt.Errorf("wait operator DeploymentAvailable: %w", err)
+	}
+	klog.Infof("LoadImageToCluster reuse: operator rollout complete")
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to reuse platform-, onboarding- and MCP-clusters created during local e2e tests.
This should enhance the developer experience with faster iteration cycles. 

Some design-decisions / information:
- This feature _should_ be **non-breaking**. I say it _should_, because I had to adjust some functions to be idempotent. E.g. `CreateIgnoreAlreadyExists()` to `CreateOrUpdate()`. I don't expect this to be breaking in any setups, but it is not guaranteed. It is however important as my design expects a complete idempotent `Setup()` of the test-environment and the individual tests (more in the next bullet point)
- To keep the logic for this as straight forward as possible, I decided to implement the "reusability" as the absence of a `Teardown()`. And on the next run, the **idempotent** `Setup()` step will just pick up the still-existing cluster, and will directly fulfill it's `assess` steps.
- For `Setup()` to be idempotent, the initial cluster name of the platform cluster needs to be hardcoded instead of randomly generated as it is now. I set it per default to "e2e-platform", and it is adjustable. Not that this way multiple e2e-tests cannot run in parallel. I don't think that is a use-case anyway.
- The shared test-environment setup in `main_test.go` can use the new "re-use" logic without any code changes. It is activated purely with the `E2E_REUSE_CLUSTER=true` env variable.
- A lot of time is also spent on the `Setup()` part of the individual tests, as I noticed that often e.g. ManagedControlPlane resources are spawned here (and deleted again in `Teardown()`). With the correct setup (which most tests _should_ already have, but it is not guaranteed: At the end of the test, the MCP has to be as pure as it was after the creation!), these ManagedControlPlanes are also reusable by just not calling these `Teardown()` parts when reuse mode is active. However, this has to be implemented in every test itself and cannot be passed down to this library, as it doesn't have control of the `Teardown()` function here. However, a `if !setup.IsReuseMode() {` helper has been created to make this easy. An example has been added to the "demo" e2e test of this repo.

**Which issue(s) this PR fixes**:
Fixes #36 .

**Special notes for your reviewer**:
- I successfully tested it with the [service-provider-flux](https://github.com/openmcp-project/service-provider-flux) e2e tests. As noted above, for the individual tests MCP clusters to also be reusable, the `Teardown()` function has to be adjusted. This has to be done in a separate PR.
- I splitted this feature into multiple commits, that logically build-up. I hope this makes a review easier and less messy.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
ability to reuse clusters of e2e tests for faster local dev iterations
```
