### PR TITLE
feat: controlplane renaming

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -23,20 +23,20 @@ func TestMain(m *testing.M) {
 		Namespace: "openmcp-system",
 		Operator: setup.OpenMCPOperatorSetup{
 			Name:         "openmcp-operator",
-			Image:        "ghcr.io/openmcp-project/images/openmcp-operator:v0.19.0",
+			Image:        "ghcr.io/openmcp-project/images/openmcp-operator:v1.0.0",
 			Environment:  "debug",
 			PlatformName: "platform",
 		},
 		ClusterProviders: []providers.ClusterProviderSetup{
 			{
 				Name:  "kind",
-				Image: "ghcr.io/openmcp-project/images/cluster-provider-kind:v0.2.0",
+				Image: "ghcr.io/openmcp-project/images/cluster-provider-kind:v0.4.1",
 			},
 		},
 		ServiceProviders: []providers.ServiceProviderSetup{
 			{
 				Name:  "crossplane",
-				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v0.4.1",
+				Image: "ghcr.io/openmcp-project/images/service-provider-crossplane:v1.0.0",
 			},
 		},
 		PlatformServices: []platformservices.PlatformServiceSetup{

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -57,9 +57,9 @@ type ClusterProviderSetup struct {
 
 func mcpRef(ref types.NamespacedName) *unstructured.Unstructured {
 	return internal.UnstructuredRef(ref.Name, ref.Namespace, schema.GroupVersionKind{
-		Group:   "core.openmcp.cloud",
+		Group:   "core.open-control-plane.io",
 		Version: "v2alpha1",
-		Kind:    "managedcontrolplanev2",
+		Kind:    "controlplane",
 	})
 }
 

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -38,8 +38,8 @@ spec:
 `
 
 const mcpTemplate = `
-apiVersion: core.openmcp.cloud/v2alpha1
-kind: ManagedControlPlaneV2
+apiVersion: core.open-control-plane.io/v2alpha1
+kind: ControlPlane
 metadata:
   name: {{.Name}}
 spec:


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Adjust the ControlPlane template to work with openmcp-operator v1.0.0.

Existing e2e tests need to specifiy openmcp-operator >=v1.0.0 in `OpenMCPSetup` to use this version of openmcp-testing:

```
	openmcp := setup.OpenMCPSetup{
		Namespace: "openmcp-system",
		Operator: setup.OpenMCPOperatorSetup{
			Name:         "openmcp-operator",
			Image:        "ghcr.io/openmcp-project/images/openmcp-operator:v1.0.0", // <====
			Environment:  "debug",
			PlatformName: "platform",
		},
```



**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Use the ControlPlane API instead of ManagedControlPlaneV2 to create managed control planes. This requires any existing e2e test to use openmcp-operator >=v1.0.0.
```
