### PR TITLE
fix: reduce CI memory footprint for e2e tests

### DIFF
--- a/pkg/setup/config/kind-config.yaml
+++ b/pkg/setup/config/kind-config.yaml
@@ -1,5 +1,13 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    etcd:
+      local:
+        extraArgs:
+          quota-backend-bytes: "536870912"
 nodes:
   - role: control-plane
     extraMounts:

--- a/pkg/setup/extensions/fluxcd/fluxcd.go
+++ b/pkg/setup/extensions/fluxcd/fluxcd.go
@@ -21,13 +21,14 @@ import (
 // FluxCD is a GitOps continuous delivery solution for Kubernetes that keeps clusters in sync
 // with configuration sources (like Git repositories) and automates configuration updates.
 //
-// This extension installs the following FluxCD components:
+// This extension installs the following FluxCD components by default:
 //   - source-controller: Handles source definitions (Git, Helm, OCI repositories)
 //   - kustomize-controller: Applies Kustomize overlays from sources
 //   - helm-controller: Manages Helm releases
 //   - notification-controller: Handles event notifications and webhooks
-//   - image-reflector-controller: Scans container registries for image metadata
-//   - image-automation-controller: Automates image updates in Git
+//
+// Additional components (e.g. image-reflector-controller, image-automation-controller) can be
+// enabled via the ExtraComponents field.
 //
 // All components are installed into the specified namespace (defaults to "flux-system").
 //
@@ -44,6 +45,10 @@ type FluxCD struct {
 	// Namespace is the Kubernetes namespace where FluxCD components will be installed.
 	// If empty, defaults to "flux-system".
 	Namespace string
+	// ExtraComponents lists additional FluxCD components to install beyond the default set
+	// (source-controller, kustomize-controller, helm-controller, notification-controller).
+	// Example: []string{"image-reflector-controller", "image-automation-controller"}
+	ExtraComponents []string
 }
 
 // Name returns the unique identifier for this extension.
@@ -80,10 +85,7 @@ func (f *FluxCD) Install(ctx context.Context, cfg *envconf.Config) error {
 		"helm-controller",
 		"notification-controller",
 	}
-	options.ComponentsExtra = []string{
-		"image-reflector-controller",
-		"image-automation-controller",
-	}
+	options.ComponentsExtra = f.ExtraComponents
 
 	manifest, err := fluxinstall.Generate(options, "")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Caps etcd backend quota at 512 MiB in the embedded Kind cluster config (default is 2 GiB). This prevents the Kind control-plane container from being OOM-killed on GitHub Actions `ubuntu-24.04` runners, which run multiple Kind clusters concurrently during e2e tests.
- Makes `FluxCD.ExtraComponents` a configurable field (default: empty). Removes `image-reflector-controller` and `image-automation-controller` from the default FluxCD install — neither is needed for basic HelmRelease/OCIRepository workflows, and both add ~100 MiB of memory pressure. Callers that need them can opt in explicitly.

## Test plan

- [ ] Verify e2e tests pass on CI with reduced footprint
- [ ] Verify existing callers that don't set `ExtraComponents` are unaffected (no image controllers deployed)
- [ ] Verify callers that need image controllers can set `ExtraComponents: []string{"image-reflector-controller", "image-automation-controller"}`