### PR TITLE
feat(cluster-providers): enable deployment and profile configuration

### DIFF
--- a/internal/testdata/config.tmpl
+++ b/internal/testdata/config.tmpl
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+data:
+  config: |
+    managedControlPlane:
+      mcpClusterPurpose: mcp
+    scheduler:
+      scope: Cluster
+      purposeMappings:
+        {{- range .ExtraClusterPurposeMapping }}
+        {{ .Purpose}}:
+          template:
+            spec:
+              profile: {{.Profile}}
+              tenancy: {{ .Tenancy }}
+        {{- end }}
+---

--- a/internal/testdata/expected_config.yaml
+++ b/internal/testdata/expected_config.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openmcp-operator
+  namespace: openmcp-system
+data:
+  config: |
+    managedControlPlane:
+      mcpClusterPurpose: mcp
+    scheduler:
+      scope: Cluster
+      purposeMappings:
+        test1:
+          template:
+            spec:
+              profile: profile1
+              tenancy: Shared
+        test2:
+          template:
+            spec:
+              profile: profile2
+              tenancy: Exclusive
+---

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,23 +1,81 @@
-package internal
+package internal_test
 
 import (
 	"bufio"
+	"bytes"
 	"embed"
 	"os"
 	"testing"
 
+	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	"github.com/openmcp-project/openmcp-testing/internal"
+	"github.com/openmcp-project/openmcp-testing/pkg/providers"
+	"github.com/openmcp-project/openmcp-testing/pkg/setup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-//go:embed testdata/test.txt
+//go:embed testdata/*
 var testFS embed.FS
 
 func TestMustTmpFileFromEmbedFS(t *testing.T) {
-	result := MustTmpFileFromEmbedFS(testFS, "testdata/test.txt")
+	result := internal.MustTmpFileFromEmbedFS(testFS, "testdata/test.txt")
 	file, err := os.Open(result)
 	require.NoError(t, err)
 	scanner := bufio.NewScanner(file)
 	require.True(t, scanner.Scan())
 	require.Equal(t, scanner.Text(), "hello openmcp!")
 	os.RemoveAll(result)
+}
+
+func TestExecTemplateFile(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		filePath string
+		data     interface{}
+		wantFile string
+		wantErr  bool
+	}{
+		{
+			name:     "test openmcp-operator purpose mapping",
+			filePath: "testdata/config.tmpl",
+			wantFile: "testdata/expected_config.yaml",
+			data: setup.OpenMCPOperatorSetup{
+				Name:      "openmcp-operator",
+				Namespace: "openmcp-system",
+				ExtraClusterPurposeMapping: []providers.ClusterPurposeMapping{
+					{
+						Purpose: "test1",
+						Profile: "profile1",
+						Tenancy: clustersv1alpha1.TENANCY_SHARED,
+					},
+					{
+						Purpose: "test2",
+						Profile: "profile2",
+						Tenancy: clustersv1alpha1.TENANCY_EXCLUSIVE,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := internal.ExecTemplateFile(tt.filePath, tt.data)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("ExecTemplateFile() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("ExecTemplateFile() succeeded unexpectedly")
+			}
+			// compare to expected file
+			expected, err := os.ReadFile(tt.wantFile)
+			require.NoError(t, err)
+			assert.Equal(t, bytes.NewBuffer(expected).String(), got)
+		})
+	}
 }

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/openmcp-project/openmcp-testing/internal"
 	"github.com/openmcp-project/openmcp-testing/pkg/providers"
 	"github.com/openmcp-project/openmcp-testing/pkg/setup"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //go:embed testdata/*

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -2,8 +2,16 @@ package providers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	providerv1alpha1 "github.com/openmcp-project/openmcp-operator/api/provider/v1alpha1"
+
+	"github.com/openmcp-project/openmcp-testing/internal"
+	"github.com/openmcp-project/openmcp-testing/pkg/clusterutils"
+	openmcpconditions "github.com/openmcp-project/openmcp-testing/pkg/conditions"
+	"github.com/openmcp-project/openmcp-testing/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,11 +21,6 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-
-	"github.com/openmcp-project/openmcp-testing/internal"
-	"github.com/openmcp-project/openmcp-testing/pkg/clusterutils"
-	openmcpconditions "github.com/openmcp-project/openmcp-testing/pkg/conditions"
-	"github.com/openmcp-project/openmcp-testing/pkg/resources"
 )
 
 const clusterProviderTemplate = `
@@ -53,6 +56,15 @@ type ClusterProviderSetup struct {
 	WaitOpts []wait.Option
 	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
 	LoadImageToCluster bool
+	// DeploymentSpec allows detailed deployment configuration.
+	DeploymentSpec *providerv1alpha1.DeploymentSpec
+}
+
+// ClusterPurposeMapping is used to configure the openmcp-operator cluster scheduler
+type ClusterPurposeMapping struct {
+	Purpose string
+	Profile string
+	Tenancy clustersv1alpha1.Tenancy
 }
 
 func mcpRef(ref types.NamespacedName) *unstructured.Unstructured {
@@ -102,6 +114,20 @@ func clusterRequestRefList() *unstructured.UnstructuredList {
 // InstallClusterProvider creates a cluster provider object on the platform cluster and waits until it is ready
 func InstallClusterProvider(ctx context.Context, c *envconf.Config, clusterProvider ClusterProviderSetup) error {
 	klog.Infof("create cluster provider %s", clusterProvider.Name)
+	if clusterProvider.DeploymentSpec != nil {
+		// create cluster provider based on deployment spec instead of template
+		if err := providerv1alpha1.AddToScheme(c.Client().Resources().GetScheme()); err != nil {
+			return fmt.Errorf("failed to add provider scheme: %w", err)
+		}
+		cp := &providerv1alpha1.ClusterProvider{}
+		cp.Name = clusterProvider.Name
+		cp.Spec.DeploymentSpec = *clusterProvider.DeploymentSpec
+		cp.Spec.Image = clusterProvider.Image
+		if err := c.Client().Resources().Create(ctx, cp); err != nil {
+			return fmt.Errorf("failed to install ClusterProvider based on DeploymentSpec: %w", err)
+		}
+		return wait.For(openmcpconditions.Match(cp, c, "Ready", corev1.ConditionTrue), clusterProvider.WaitOpts...)
+	}
 	obj, err := resources.CreateObjectFromTemplate(ctx, c, clusterProviderTemplate, clusterProvider)
 	if err != nil {
 		return err

--- a/pkg/providers/clusterprovider.go
+++ b/pkg/providers/clusterprovider.go
@@ -8,10 +8,6 @@ import (
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
 	providerv1alpha1 "github.com/openmcp-project/openmcp-operator/api/provider/v1alpha1"
 
-	"github.com/openmcp-project/openmcp-testing/internal"
-	"github.com/openmcp-project/openmcp-testing/pkg/clusterutils"
-	openmcpconditions "github.com/openmcp-project/openmcp-testing/pkg/conditions"
-	"github.com/openmcp-project/openmcp-testing/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -21,6 +17,11 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/openmcp-project/openmcp-testing/internal"
+	"github.com/openmcp-project/openmcp-testing/pkg/clusterutils"
+	openmcpconditions "github.com/openmcp-project/openmcp-testing/pkg/conditions"
+	"github.com/openmcp-project/openmcp-testing/pkg/resources"
 )
 
 const clusterProviderTemplate = `

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -48,6 +48,8 @@ type OpenMCPOperatorSetup struct {
 	WaitOpts     []wait.Option
 	// LoadImageToCluster allows using local images that have to be loaded into the kind cluster
 	LoadImageToCluster bool
+	// ExtraClusterPurposeMapping allows to provide additional cluster purpose mappings for the cluster scheduler
+	ExtraClusterPurposeMapping []providers.ClusterPurposeMapping
 }
 
 // Bootstrap sets up the minimum set of components of an openMCP installation and returns the platform cluster name
@@ -114,6 +116,31 @@ func (s *OpenMCPSetup) verifyEnvironment() types.EnvFunc {
 
 func (s *OpenMCPSetup) installOpenMCPOperator(tmpl string) types.EnvFunc {
 	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
+		// default purpose mapping
+		purposeMapping := []providers.ClusterPurposeMapping{
+			{
+				Purpose: "mcp",
+				Profile: "kind",
+				Tenancy: "Exclusive",
+			},
+			{
+				Purpose: "platform",
+				Profile: "kind",
+				Tenancy: "Shared",
+			},
+			{
+				Purpose: "onboarding",
+				Profile: "kind",
+				Tenancy: "Shared",
+			},
+			{
+				Purpose: "workload",
+				Profile: "kind",
+				Tenancy: "Shared",
+			},
+		}
+		s.Operator.ExtraClusterPurposeMapping = append(s.Operator.ExtraClusterPurposeMapping, purposeMapping...)
+
 		// apply openmcp operator manifests
 		if _, err := resources.CreateObjectsFromTemplateFile(ctx, c, tmpl, s.Operator); err != nil {
 			return ctx, err

--- a/pkg/setup/config/operator.yaml.tmpl
+++ b/pkg/setup/config/operator.yaml.tmpl
@@ -29,26 +29,13 @@ data:
     scheduler:
       scope: Cluster
       purposeMappings:
-        mcp:
+        {{- range .ExtraClusterPurposeMapping }}
+        {{ .Purpose}}:
           template:
             spec:
-              profile: kind
-              tenancy: Exclusive
-        platform:
-          template:
-            spec:
-              profile: kind
-              tenancy: Shared
-        onboarding:
-          template:
-            spec:
-              profile: kind
-              tenancy: Shared
-        workload:
-          template:
-            spec:
-              profile: kind
-              tenancy: Shared
+              profile: {{.Profile}}
+              tenancy: {{ .Tenancy }}
+        {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
This PR adds the following optional configuration parameters for cluster provider testing:
- `OpenMCPOperatorSetup.ExtraClusterPurposeMapping`: add extra cluster profile mappings to the openmcp-operator configuration
- `ClusterProviderSetup.DeploymentSpec`: allow to override the default DeploymentSpec which is currently tailored for cluster-provider-kind.

**Which issue(s) this PR fixes**:
Required by the cluster-provider template: https://github.com/openmcp-project/backlog/issues/611

**Special notes for your reviewer**:
Usage example https://github.com/openmcp-project/cluster-provider-template/pull/1

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
cluster provider deployment and profile configuration with the following new optional parameters:
- OpenMCPOperatorSetup.ExtraClusterPurposeMapping: add extra cluster profile mappings to the openmcp-operator configuration
- ClusterProviderSetup.DeploymentSpec: allow to override the default DeploymentSpec which is currently tailored for cluster-provider-kind.
```
