### PR TITLE
feat: add support for registry mirrors

### DIFF
--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -294,10 +294,7 @@ func appendMirrorsToKindConfig(kindConfigFile string, mirrors map[string]string)
 	var patches strings.Builder
 	patches.WriteString("\ncontainerdConfigPatches:\n")
 	for registry, mirror := range mirrors {
-		patches.WriteString(fmt.Sprintf(`- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."%s"]
-    endpoint = ["%s"]
-`, registry, mirror))
+		fmt.Fprintf(&patches, "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = [\"%s\"]\n", registry, mirror)
 	}
 	f, err := os.OpenFile(kindConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {

--- a/pkg/setup/bootstrap.go
+++ b/pkg/setup/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"strings"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,6 +38,10 @@ type OpenMCPSetup struct {
 	PlatformServices []platformservices.PlatformServiceSetup
 	Extensions       []extensions.Extension
 	WaitOpts         []wait.Option
+	// ContainerdMirrors maps a registry hostname (e.g. "ghcr.io") to a mirror
+	// endpoint (e.g. "http://localhost:5000"). When set, the kind cluster config
+	// is patched so containerd routes pulls for that registry through the mirror.
+	ContainerdMirrors map[string]string
 }
 
 type OpenMCPOperatorSetup struct {
@@ -55,6 +60,11 @@ type OpenMCPOperatorSetup struct {
 // Bootstrap sets up the minimum set of components of an openMCP installation and returns the platform cluster name
 func (s *OpenMCPSetup) Bootstrap(testenv env.Environment) string {
 	kindConfig := internal.MustTmpFileFromEmbedFS(configFS, "config/kind-config.yaml")
+	if len(s.ContainerdMirrors) > 0 {
+		if err := appendMirrorsToKindConfig(kindConfig, s.ContainerdMirrors); err != nil {
+			panic(fmt.Sprintf("failed to patch kind config with containerd mirrors: %v", err))
+		}
+	}
 	operatorTemplate := internal.MustTmpFileFromEmbedFS(configFS, "config/operator.yaml.tmpl")
 	platformClusterName := envconf.RandomName("platform", 16)
 	s.Operator.Namespace = s.Namespace
@@ -275,6 +285,27 @@ func (s *OpenMCPSetup) loadImagesToCluster(platformCluster string) env.Func {
 		}
 	}
 	return Compose(funcs...)
+}
+
+// appendMirrorsToKindConfig appends containerdConfigPatches to an existing
+// kind config YAML file so that containerd inside the cluster routes pulls
+// for the given registry hostnames through the provided mirror endpoints.
+func appendMirrorsToKindConfig(kindConfigFile string, mirrors map[string]string) error {
+	var patches strings.Builder
+	patches.WriteString("\ncontainerdConfigPatches:\n")
+	for registry, mirror := range mirrors {
+		patches.WriteString(fmt.Sprintf(`- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."%s"]
+    endpoint = ["%s"]
+`, registry, mirror))
+	}
+	f, err := os.OpenFile(kindConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open kind config: %w", err)
+	}
+	defer f.Close()
+	_, err = f.WriteString(patches.String())
+	return err
 }
 
 // Compose executes multiple env.Funcs in a row


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `ContainerdMirrors` field to `OpenMCPSetup`, allowing tests to route container image pulls for specific registries (e.g. `ghcr.io`) through a local mirror (e.g. `http://localhost:5000`). Useful in air-gapped or rate-limited CI environments. When set, the kind cluster config is patched with `containerdConfigPatches` before cluster creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Usage example:
```go
setup := &OpenMCPSetup{
    ContainerdMirrors: map[string]string{
        "ghcr.io": "http://localhost:5000",
    },
    // ...
}
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add `ContainerdMirrors` support to `OpenMCPSetup` for routing registry pulls through local mirrors in kind-based test environments.
```